### PR TITLE
Enable sbt-buildinfo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -27,8 +27,13 @@ lazy val plugin = project
     moduleName := "sbt-native-image",
     sbtPlugin := true,
     sbtVersion.in(pluginCrossBuild) := "1.0.0",
-    crossScalaVersions := List(scala212)
+    crossScalaVersions := List(scala212),
+    buildInfoPackage := "sbtnativeimage",
+    buildInfoKeys := Seq[BuildInfoKey](
+      version
+    )
   )
+  .enablePlugins(BuildInfoPlugin)
 
 lazy val example = project
   .in(file("example"))

--- a/plugin/src/main/scala/sbtnativeimage/NativeImagePlugin.scala
+++ b/plugin/src/main/scala/sbtnativeimage/NativeImagePlugin.scala
@@ -1,4 +1,4 @@
-package sbtnativeImage
+package sbtnativeimage
 
 import java.io.File
 import java.nio.file.Files

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 unmanagedSourceDirectories.in(Compile) +=
   baseDirectory.in(ThisBuild).value.getParentFile /


### PR DESCRIPTION
This makes it possible to programmatically access the version of
sbt-native-image.