### PR TITLE
Various updates for actions, sbt, and plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [macOS-latest, ubuntu-latest, windows-latest]
         java: [8]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         java: [8]
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: "adopt@1.${{ matrix.java }}"
       - name: sbt test plugin/scripted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
         shell: bash
         run: |
           export JABBA=/home/runner/bin/jabba
-          $JABBA install graalvm@20.1.0
-          export GRAALVM_HOME=$($JABBA which --home graalvm@20.1.0)
+          $JABBA install graalvm@20.2.0
+          export GRAALVM_HOME=$($JABBA which --home graalvm@20.2.0)
           $GRAALVM_HOME/bin/gu install native-image
           export NATIVE_IMAGE_COMMAND=$GRAALVM_HOME/bin/native-image
           sbt test plugin/scripted

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -26,7 +26,7 @@ jobs:
             local_path: example\target\native-image\example.exe
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v6
+      - uses: olafurpg/setup-scala@v10
       - run: git fetch --tags || true
       - run: sbt example/nativeImage
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: olafurpg/setup-scala@v2
-      - uses: olafurpg/setup-gpg@v2
+      - uses: olafurpg/setup-scala@v10
+      - uses: olafurpg/setup-gpg@v3
       - run: git fetch --tags || true
       - name: Publish ${{ github.ref }}
         run: sbt ci-release

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.0-RC1
+sbt.version=1.4.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.3")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.4")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 


### PR DESCRIPTION
This bumbs the version of various things.
- Bumps the graalvm version installed in ci.yml to match the default version from the plugin
- Bump sbt from the RC to the latest 1.4.4
- Bump both sbt plugins (BuildInfo and sbt-ci-release)
- Bump the action versions
- Add in settings for dependabot to keep actions up to date (like we did in the other scalameta projects)