### PR TITLE
make nativeImageJvm key description more accurate

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -158,10 +158,14 @@ CI to generate the binary in a specific place.
 
 **Description**: the GraalVM JVM version to use.
 
-**Default**: `"graalvm-java11"`. Must be one of: `"graalvm-java11"`, `"graalvm"`
-(Java 8).
+**Default**: `"graalvm-java11"`. Must be one of the combinations below.
 
 **Example usage**: `nativeImageJvm := "graalvm"`
+
+|nativeImageJvm|nativeImageVersion|nativeImageJvmIndex|source|
+|---|---|---|---|
+|graalvm, graalvm-java11|1.0.0-x,19.0.0~21.1.0|cs|https://github.com/coursier/jvm-index|
+|graalvm-ce-java8, graalvm-ce-java11, gaalvm-ce-java16|19.3~21.1.0|jabba|https://raw.githubusercontent.com/shyiko/jabba/master/index.json|
 
 ### `nativeImageJvmIndex`
 


### PR DESCRIPTION
nativeImageJvm can accept not only graalvm or graalvm-java11 but also
graalvm-ce-java8, 11 and 16 grom jabba index.