### PR TITLE
nativeImageRunAgent should depend on nativeImageCommand

### DIFF
--- a/plugin/src/main/scala/sbtnativeimage/NativeImagePlugin.scala
+++ b/plugin/src/main/scala/sbtnativeimage/NativeImagePlugin.scala
@@ -217,6 +217,7 @@ object NativeImagePlugin extends AutoPlugin {
     nativeImageAgentOutputDir := target.value / "native-image-configs",
     nativeImageAgentMerge := false,
     nativeImageRunAgent := {
+      val _ = nativeImageCommand.value
       val graalHome = nativeImageGraalHome.value.toFile
       val agentConfig =
         if (nativeImageAgentMerge.value)


### PR DESCRIPTION
Running `nativeImageRunAgent` before `nativeImage` will fail due to
`Could not find agent library native-image-agent on the library path`
error. Thus, it should depend on `nativeImageCommand` to fetch missing dependencies.