### PR TITLE
Fix GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-2019]
+        os: [macOS-latest, ubuntu-latest, windows-latest]
         java: [8]
     steps:
       - uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
           java-version: "adopt@1.${{ matrix.java }}"
       - name: Setup Windows C++ toolchain
         uses: ilammy/msvc-dev-cmd@v1
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-latest' }}
       - name: sbt test plugin/scripted
         if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
@@ -34,7 +34,7 @@ jobs:
           sbt test plugin/scripted
       - name: sbt test
         shell: bash
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-latest' }}
         run: |
           sbt example/nativeImage
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,19 +6,22 @@ on:
       - main
   pull_request:
 jobs:
-  unix:
+  native-image:
     name: Compile
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]
+        os: [macOS-latest, ubuntu-latest, windows-2019]
         java: [8]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: olafurpg/setup-scala@v13
         with:
           java-version: "adopt@1.${{ matrix.java }}"
+      - name: Setup Windows C++ toolchain
+        uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ matrix.os == 'windows-2019' }}
       - name: sbt test plugin/scripted
         if: ${{ matrix.os == 'ubuntu-latest' }}
         shell: bash
@@ -30,15 +33,13 @@ jobs:
           export NATIVE_IMAGE_COMMAND=$GRAALVM_HOME/bin/native-image
           sbt test plugin/scripted
       - name: sbt test
-        shell: cmd
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: >-
-          "C:\Program Files (x86)\Microsoft Visual
-          Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && sbt
-          example/nativeImage
+        shell: bash
+        if: ${{ matrix.os == 'windows-2019' }}
+        run: |
+          sbt example/nativeImage
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: olafurpg/setup-scala@v13
       - run: sbt checkAll

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-2019]
+        os: [macOS-latest, ubuntu-latest, windows-latest]
         include:
           # Replace "example" with the name your binary
           - os: macOS-latest
@@ -22,7 +22,7 @@ jobs:
           - os: ubuntu-latest
             uploaded_filename: example-x86_64-pc-linux
             local_path: example/target/native-image/example
-          - os: windows-2019
+          - os: windows-latest
             uploaded_filename: example-x86_64-pc-win32.exe
             local_path: example\target\native-image\example.exe
     env:
@@ -40,7 +40,7 @@ jobs:
       - run: git fetch --tags || true
       - name: Setup Windows C++ toolchain
         uses: ilammy/msvc-dev-cmd@v1
-        if: ${{ matrix.os == 'windows-2019' }}
+        if: ${{ matrix.os == 'windows-latest' }}
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -8,12 +8,12 @@ on:
   release:
     types: [published]
 jobs:
-  unix:
+  native-image:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]
+        os: [macOS-latest, ubuntu-latest, windows-2019]
         include:
           # Replace "example" with the name your binary
           - os: macOS-latest
@@ -22,25 +22,30 @@ jobs:
           - os: ubuntu-latest
             uploaded_filename: example-x86_64-pc-linux
             local_path: example/target/native-image/example
-          - os: windows-latest
+          - os: windows-2019
             uploaded_filename: example-x86_64-pc-win32.exe
             local_path: example\target\native-image\example.exe
+    env:
+      # define Java options for both official sbt and sbt-extras
+      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
-      - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v13
+      - uses: actions/checkout@v3
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: sbt
       - run: git fetch --tags || true
-      - run: sbt example/nativeImage
+      - name: Setup Windows C++ toolchain
+        uses: ilammy/msvc-dev-cmd@v1
+        if: ${{ matrix.os == 'windows-2019' }}
+      - name: Build
         shell: bash
-        if: ${{ matrix.os != 'windows-latest' }}
-      - run: echo $(pwd)
-        shell: bash
-      - name: sbt test
-        shell: cmd
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: >-
-          "C:\Program Files (x86)\Microsoft Visual
-          Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" && sbt
-          example/nativeImage
+        run: |
+          echo $(pwd)
+          sbt clean example/nativeImage
       - uses: actions/upload-artifact@v2
         with:
           path: ${{ matrix.local_path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: olafurpg/setup-scala@v13
       - uses: olafurpg/setup-gpg@v3
       - run: git fetch --tags || true


### PR DESCRIPTION
This fixes GitHub Actions to it builds native image.
1. Use ilammy/msvc-dev-cmd to setup C++ toolchain on Windows.
2. Downgrade to windows-2019, instead of windows-latest
3. Use `setup-java@v3`
4. Use `actions/checkout@v3`
5. Call clean on sbt
6. Fix a typo that was saying "unix" before