### PR TITLE
fix: remove CMSClassUnloadingEnabled which doesn't work on 17

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -3,5 +3,4 @@
 -Xmx2G
 -XX:ReservedCodeCacheSize=1024m
 -XX:+TieredCompilation
--XX:+CMSClassUnloadingEnabled
 -Dfile.encoding=UTF-8


### PR DESCRIPTION
Just merged in a couple prs and trying to get this up to date and 🟢 again in CI, but this was biting me locally.