### PR TITLE
Bump sbt so it work on ARM-based Mac

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.4
+sbt.version=1.9.9


### PR DESCRIPTION
`sbt` does not boot up on this repo on ARM-based Mac (M1, M2, and M3) since sbt version 1.4.4 does not support them
https://github.com/sbt/sbt/issues/6619



> [error] [launcher] error during sbt launcher: java.lang.UnsatisfiedLinkError: /Users/exoego/Library/Caches/JNA/temp/jna6324089378985108447.tmp: dlopen(/Users/exoego/Library/Caches/JNA/temp/jna6324089378985108447.tmp, 0x0001): tried: '/Users/exoego/Library/Caches/JNA/temp/jna6324089378985108447.tmp' (fat file, but missing compatible architecture (have 'i386,x86_64', need 'arm64e' or 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/exoego/Library/Caches/JNA/temp/jna6324089378985108447.tmp' (no such file), '/Users/exoego/Library/Caches/JNA/temp/jna6324089378985108447.tmp' (fat file, but missing compatible architecture (have 'i386,x86_64', need 'arm64e' or 'arm64'))



