### PR TITLE
fix: Fixes windows-2025 support

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -29,6 +29,10 @@ jobs:
             uploaded_filename: example-x86_64-pc-win32.exe
             local_path: example\target\native-image\example.exe
             arch: x64
+          - os: windows-2022
+            uploaded_filename: example2022-x86_64-pc-win32.exe
+            local_path: example\target\native-image\example.exe
+            arch: x64
     env:
       # define Java options for both official sbt and sbt-extras
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8

--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15-intel, ubuntu-latest]
+        os: [macos-14, macos-15-intel, ubuntu-latest, windows-2025]
         include:
           # Replace "example" with the name your binary
           - os: macos-14
@@ -25,11 +25,10 @@ jobs:
           - os: ubuntu-latest
             uploaded_filename: example-x86_64-pc-linux
             local_path: example/target/native-image/example
-
-          # TODO: Fix Windows support
-          # - os: windows-2022
-          #   uploaded_filename: example-x86_64-pc-win32.exe
-          #   local_path: example\target\native-image\example.exe
+          - os: windows-2025
+            uploaded_filename: example-x86_64-pc-win32.exe
+            local_path: example\target\native-image\example.exe
+            arch: x64
     env:
       # define Java options for both official sbt and sbt-extras
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
@@ -46,7 +45,9 @@ jobs:
       - run: git fetch --tags || true
       - name: Setup Windows C++ toolchain
         uses: ilammy/msvc-dev-cmd@v1
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: runner.os == 'Windows'
+        with:
+          arch: ${{ matrix.arch }}
       - name: Build
         shell: bash
         run: |

--- a/plugin/src/main/resources/sbt-native-image/coursier.bat
+++ b/plugin/src/main/resources/sbt-native-image/coursier.bat
@@ -1,6 +1,9 @@
 @echo off
 
-
+setlocal EnableDelayedExpansion
+(set LF=^
+%=%
+)
 
 @REM set %HOME% to equivalent of $HOME
 if "%HOME%" == "" (set HOME=%HOMEDRIVE%%HOMEPATH%)
@@ -63,13 +66,16 @@ goto Win9xApp
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-set JAR_PATH=%~dp0\%~n0
-SET PROG_DIR=%~dp0
-SET PSEP=;
+set PROG_DIR=%~dp0
+@REM Remove trailing backslash from PROG_DIR
+if %PROG_DIR:~-1%==\ set PROG_DIR=%PROG_DIR:~0,-1%
+set JAR_PATH=%PROG_DIR%\%~n0
+set PSEP=;
 
 @REM Start Java program
 :runm2
-SET CMDLINE=%JAVA_EXE%  %JAVA_OPTS% -Dprog.dir="%PROG_DIR:\=\\%" -jar "%JAR_PATH%" %CMD_LINE_ARGS%
+call set _JAVA_OPTS=%%JAVA_OPTS:!LF!= %%
+set CMDLINE=%JAVA_EXE% %_JAVA_OPTS% -Dprog.dir="%PROG_DIR%" -jar "%JAR_PATH%" %CMD_LINE_ARGS%
 %CMDLINE%
 if ERRORLEVEL 1 goto error
 goto end


### PR DESCRIPTION
## Problem
Currently the plugin fails to acquire java-home when invoking
coursier.bat on windows-2025 runner.

## Solution
1. This removes duplicate backslash in `JAR_PATH`
2. This also removes newline string in `JAVA_OPTS` environment variable